### PR TITLE
fix: add explanations about netflix email at each connection

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # General code owners
-*      @doubleface @LucsT @aenario @sebn
+*      @konnectors/maintainers

--- a/manifest.konnector
+++ b/manifest.konnector
@@ -63,7 +63,7 @@
   "locales": {
     "fr": {
       "short_description": "Connecteur Netflix",
-      "long_description": "Ce connecteur récupère vos factures et historique d'activité Netflix",
+      "long_description": "Ce connecteur récupère vos factures et historique d'activité Netflix. Il faut savoir qu'à chaque fois que ce service se connectera à Netflix, vous recevrez un mail indiquant \"un nouvel accès à votre compte\".",
       "permissions": {
         "bank operations": {
           "description": "Utilisé pour relier les factures à des operations bancaires"
@@ -87,7 +87,7 @@
     },
     "en": {
       "short_description": "Netflix Connector",
-      "long_description": "This connector fetches your netflix invoices and views",
+      "long_description": "This connector fetches your netflix invoices and views. You have to know that you will get an email indicating \"a new access to your account\" each time the service will access netflix.",
       "permissions": {
         "bank operations": {
           "description": "Required to link bank operations to bills"

--- a/manifest.konnector
+++ b/manifest.konnector
@@ -63,7 +63,7 @@
   "locales": {
     "fr": {
       "short_description": "Connecteur Netflix",
-      "long_description": "Ce connecteur récupère vos factures et historique d'activité Netflix. Il faut savoir qu'à chaque fois que ce service se connectera à Netflix, vous recevrez un mail indiquant \"un nouvel accès à votre compte\".",
+      "long_description": "Ce connecteur récupère vos factures et historique d'activité de votre compte Netflix. À chaque nouvelle connexion de ce service à Netflix, un email \"un nouvel accès à votre compte\" vous sera envoyé. Ce comportement est parfaitement normal.",
       "permissions": {
         "bank operations": {
           "description": "Utilisé pour relier les factures à des operations bancaires"
@@ -87,7 +87,7 @@
     },
     "en": {
       "short_description": "Netflix Connector",
-      "long_description": "This connector fetches your netflix invoices and views. You have to know that you will get an email indicating \"a new access to your account\" each time the service will access netflix.",
+      "long_description": "This connector fetches your netflix invoices and views. Everytime your Cozy access your Netflix account, you will be sent an email saying \"a new access to your account\". This behaviour is completely normal.",
       "permissions": {
         "bank operations": {
           "description": "Required to link bank operations to bills"


### PR DESCRIPTION
There is problably a better to explain it (in english and in french)